### PR TITLE
Update OndatoSDK.podspec

### DIFF
--- a/OndatoSDK.podspec
+++ b/OndatoSDK.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |spec|
   spec.license  	   = 'Apache-2.0'
   spec.homepage     = 'https://github.com/ondato/ondato-sdk-ios'
   spec.authors      = { 'Ondato' => 'info@ondato.com' }
-  spec.source       = { :git => 'git@github.com:ondato/ondato-sdk-ios.git', :tag => spec.version }
+  spec.source       = { :git => 'https://github.com/ondato/ondato-sdk-ios.git', :tag => spec.version }
   spec.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
   spec.ios.vendored_frameworks  = 'OndatoSDK.framework', 'FaceTecSDK.framework', 'SwiftyTesseract.framework', 'libtesseract.xcframework'
   spec.dependency "OpenSSL-Universal", '1.1.180'


### PR DESCRIPTION
Update source of podspec to use https format instead of ssh.

With ssh format it prevents you from simply doing `pod 'OndatoSDK'`. You would need to add ssh keys to github. Using https prevents this issue